### PR TITLE
Add `--no-deps` to `pip install`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -r requirements.txt
+        python -m pip install -r requirements.txt --no-deps
     
     - name: Run pytest
       run: pytest


### PR DESCRIPTION
The requirements file already has resolved dependencies, so this is not needed by the CI and avoids unnecessary error. 